### PR TITLE
Add links to the comic strip images in README files

### DIFF
--- a/Elvie_000/README.md
+++ b/Elvie_000/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #000](Elvie_000_en-GB.jpg)
+
 Elvie #000
 ==========
 This is a prequel comic to introduce the character of Elvie. This strip appeared on our website, but not in 'Linux Voice'.

--- a/Elvie_001/README.md
+++ b/Elvie_001/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #001](Elvie_001_en-GB.jpg)
+
 Elvie #001
 ==========
 This is the first Elvie strip that was created (which is why the character looks a little different to her appearance in later strips). This strip appeared in issue #1 of 'Linux Voice' magazine, with the joke tailored accordingly.

--- a/Elvie_002/README.md
+++ b/Elvie_002/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #002](Elvie_002_en-GB.jpg)
+
 Elvie #002
 ==========
 This Elvie strip appeared in issue #2 of 'Linux Voice' magazine, which included an article on building an arcade machine using a Raspberry Pi, and an article about Grace Hopper. These two articles were combined to form the basis of this strip.

--- a/Elvie_003/README.md
+++ b/Elvie_003/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #003](Elvie_003_en-GB.jpg)
+
 Elvie #003
 ==========
 This Elvie strip appeared in issue #3 of 'Linux Voice' magazine, which included an article on command line vs graphical interfaces.

--- a/Elvie_004/README.md
+++ b/Elvie_004/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #004](Elvie_004_en-GB.jpg)
+
 Elvie #004
 ==========
 This Elvie strip appeared in issue #4 of 'Linux Voice' magazine, which included an article on Ubuntu remixes.

--- a/Elvie_005/README.md
+++ b/Elvie_005/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #005](Elvie_005_en-GB.jpg)
+
 Elvie #005
 ==========
 This Elvie strip appeared in issue #5 of 'Linux Voice' magazine, which included an article on Nethack.

--- a/Elvie_006/README.md
+++ b/Elvie_006/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #006](Elvie_006_en-GB.jpg)
+
 Elvie #006
 ==========
 This Elvie strip appeared in issue #6 of 'Linux Voice' magazine, which included an article on making a face-tracking NERF gun launcher.

--- a/Elvie_007/README.md
+++ b/Elvie_007/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #007](Elvie_007_en-GB.jpg)
+
 Elvie #007
 ==========
 This Elvie strip appeared in issue #07 of 'Linux Voice' magazine, which featured an article comparing several different distros in an effort to find the best one.

--- a/Elvie_008/README.md
+++ b/Elvie_008/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #008](Elvie_008_en-GB.jpg)
+
 Elvie #008
 ==========
 This Elvie strip appeared in issue #08 of 'Linux Voice' magazine, which featured an article about building a mail server.

--- a/Elvie_009/README.md
+++ b/Elvie_009/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #009](Elvie_009_en-GB.jpg)
+
 Elvie #009
 ==========
 This Elvie strip appeared in issue #09 of 'Linux Voice' magazine, which featured an interview with Tim O'Reilly.

--- a/Elvie_010/README.md
+++ b/Elvie_010/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #010](Elvie_010_en-GB.jpg)
+
 Elvie #010
 ==========
 This strip appeared in issue #10 of Linux Voice magazine, which featured an article about Linux vs Windows

--- a/Elvie_011/README.md
+++ b/Elvie_011/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #011](Elvie_011_en-GB.jpg)
+
 Elvie #011
 ==========
 This strip appeared in issue #11 of Linux Voice magazine, which featured an article about the

--- a/Elvie_012/README.md
+++ b/Elvie_012/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #012](Elvie_012_en-GB.jpg)
+
 Elvie #012
 ==========
 This strip appeared in issue #12 of Linux Voice magazine, which featured an article about

--- a/Elvie_013/README.md
+++ b/Elvie_013/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #013](Elvie_013_en-GB.jpg)
+
 Elvie #013
 ==========
 This strip appeared in issue #13 of Linux Voice magazine, which included the first

--- a/Elvie_014/README.md
+++ b/Elvie_014/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #014](Elvie_014_en-GB.jpg)
+
 Elvie #014
 ==========
 This strip appeared in issue #14 of Linux Voice magazine. We were told that

--- a/Elvie_015/README.md
+++ b/Elvie_015/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #015](Elvie_015_en-GB.jpg)
+
 Elvie #015
 ==========
 This strip appeared in issue #15 of Linux Voice magazine, which included an interview with Larry Wall.

--- a/Elvie_016/README.md
+++ b/Elvie_016/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #016](Elvie_016_en-GB.jpg)
+
 Elvie #016
 ==========
 This strip appeared in issue #16 of Linux Voice magazine, which included an article about Linux (and Unix) in the movies,

--- a/Elvie_017/README.md
+++ b/Elvie_017/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #017](Elvie_017_en-GB.jpg)
+
 Elvie #017
 ==========
 This strip appeared in issue #17 of Linux Voice magazine, which included an article about privacy and encryption.

--- a/Elvie_018/README.md
+++ b/Elvie_018/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #018](Elvie_018_en-GB.jpg)
+
 Elvie #018
 ==========
 This strip appeared in issue #18 of Linux Voice magazine, which included a review of the Meizu MX4 Ubuntu phone,

--- a/Elvie_019/README.md
+++ b/Elvie_019/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #019](Elvie_019_en-GB.jpg)
+
 Elvie #019
 ==========
 This strip appeared in issue #19 of Linux Voice magazine.

--- a/Elvie_020/README.md
+++ b/Elvie_020/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #020](Elvie_020_en-GB.jpg)
+
 Elvie #020
 ==========
 This strip appeared in issue #20 of Linux Voice magazine.

--- a/Elvie_021/README.md
+++ b/Elvie_021/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #021](Elvie_021_en-GB.jpg)
+
 Elvie #021
 ==========
 This strip appeared in issue #21 of Linux Voice magazine, which featured a group test of educational software.

--- a/Elvie_022/README.md
+++ b/Elvie_022/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #022](Elvie_022_en-GB.jpg)
+
 Elvie #022
 ==========
 This strip appeared in issue #22 of Linux Voice magazine, which reached subscribers shortly before

--- a/Elvie_023/README.md
+++ b/Elvie_023/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #023](Elvie_023_en-GB.jpg)
+
 Elvie #023
 ==========
 This strip appeared in issue #23 of Linux Voice magazine, which lead with an article about turning your house into a smart home.

--- a/Elvie_024/README.md
+++ b/Elvie_024/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #024](Elvie_024_en-GB.jpg)
+
 Elvie #024
 ==========
 This strip appeared in issue #24 of Linux Voice magazine, which went to print shortly after The MagPi had released issue #40

--- a/Elvie_025/README.md
+++ b/Elvie_025/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #025](Elvie_025_en-GB.jpg)
+
 Elvie #025
 ==========
 This strip appeared in issue #25 of Linux Voice magazine.

--- a/Elvie_026/README.md
+++ b/Elvie_026/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #026](Elvie_026_en-GB.jpg)
+
 Elvie #026
 ==========
 This strip appeared in issue #26 of Linux Voice magazine, which featured the third and final instalment of

--- a/Elvie_027/README.md
+++ b/Elvie_027/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #027](Elvie_027_en-GB.jpg)
+
 Elvie #027
 ==========
 This strip appeared in issue #27 of Linux Voice magazine.

--- a/Elvie_028/README.md
+++ b/Elvie_028/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #028](Elvie_028_en-GB.jpg)
+
 Elvie #028
 ==========
 This strip appeared in issue #28 of Linux Voice magazine.

--- a/Elvie_029/README.md
+++ b/Elvie_029/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #029](Elvie_029_en-GB.jpg)
+
 Elvie #029
 ==========
 This strip appeared in issue #29 of Linux Voice magazine, which contained a group

--- a/Elvie_030/README.md
+++ b/Elvie_030/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #030](Elvie_030_en-GB.jpg)
+
 Elvie #030
 ==========
 This strip appeared in issue #30 of Linux Voice magazine.

--- a/Elvie_031/README.md
+++ b/Elvie_031/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #031](Elvie_031_en-GB.jpg)
+
 Elvie #031
 ==========
 This strip appeared in issue #31 of Linux Voice magazine.

--- a/Elvie_032/README.md
+++ b/Elvie_032/README.md
@@ -1,3 +1,5 @@
+![Elvie comic strip #032](Elvie_032_en-GB.jpg)
+
 Elvie #032
 ==========
 This strip appeared in issue #32 of Linux Voice magazine, and coincided with the 25th anniversary of the first


### PR DESCRIPTION
In the `README.md` for each strip, prepend a link to the final JPEG image so that the corresponding
cartoon is visible when browsing the repo via the GitHub web UI.